### PR TITLE
Update header layout

### DIFF
--- a/gen_page.py
+++ b/gen_page.py
@@ -1,15 +1,29 @@
 from reportlab.lib.pagesizes import A6
 from reportlab.pdfgen import canvas
+from reportlab.lib.units import mm
 
 from widgets import calendar, astro
 
 DEFAULT_PATH = "page.pdf"
 
+HEADER_HEIGHT = 30 * mm
+MARGIN = 6 * mm
+
+
 def create_page(output_path=DEFAULT_PATH):
     """Create a PDF page with calendar and astronomy info."""
     c = canvas.Canvas(output_path, pagesize=A6)
-    calendar.draw(c)
-    astro.draw(c)
+
+    width, height = A6
+    header_top = height - MARGIN
+    header_bottom = header_top - HEADER_HEIGHT
+
+    calendar.draw(c, header_top, header_bottom, margin=MARGIN)
+    astro.draw(c, header_top - 12, margin=MARGIN)
+
+    c.setLineWidth(1)
+    c.line(MARGIN, header_bottom, width - MARGIN, header_bottom)
+
     c.save()
     return output_path
 

--- a/widgets/astro.py
+++ b/widgets/astro.py
@@ -2,20 +2,20 @@ from datetime import date
 from astral import LocationInfo
 from astral.sun import sun
 from reportlab.lib.pagesizes import A6
+from reportlab.lib.units import mm
 
 
-def draw(c):
-    """Draw sunrise and sunset times on the given canvas."""
+def draw(c, top_y, margin=6 * mm):
+    """Draw sunrise and sunset times at the top right of the header."""
     location = LocationInfo("London", "England", "UTC", 51.5, -0.1)
     s = sun(location.observer, date=date.today(), tzinfo=location.timezone)
 
-    sunrise = s['sunrise'].strftime('%H:%M')
-    sunset = s['sunset'].strftime('%H:%M')
+    sunrise = s["sunrise"].strftime("%H:%M")
+    sunset = s["sunset"].strftime("%H:%M")
 
-    width, height = A6
-    margin = 20
+    width, _ = A6
     x = width - margin
-    y = height - margin
+    y = top_y
 
     c.setFont("Courier", 10)
     c.drawRightString(x, y, f"Sunrise {sunrise}")

--- a/widgets/calendar.py
+++ b/widgets/calendar.py
@@ -2,28 +2,26 @@ from datetime import datetime
 import calendar
 from reportlab.lib.pagesizes import A6
 from reportlab.lib import colors
+from reportlab.lib.units import mm
 
 
-def draw(c):
-    """Draw a simple month calendar on the given canvas."""
+def draw(c, top_y, bottom_y, margin=6 * mm):
+    """Draw a simple month grid inside the given header bounds."""
     today = datetime.today()
     year = today.year
     month = today.month
     day = today.day
 
-    width, height = A6
-
-    cell_size = 20
-    start_x = 20
-    start_y = height - 40
-    padding = 6
-
-    c.setFont("Courier", 10)
-
-    month_name = calendar.month_name[month]
-    c.drawString(start_x, start_y + 20, f"{month_name} {year}")
-
     month_matrix = calendar.monthcalendar(year, month)
+    rows = len(month_matrix)
+
+    cell_size = (top_y - bottom_y) / rows
+
+    start_x = margin
+    start_y = top_y - cell_size
+    padding = cell_size * 0.3
+
+    c.setFont("Courier", 8)
 
     for row_idx, week in enumerate(month_matrix):
         for col_idx, date in enumerate(week):


### PR DESCRIPTION
## Summary
- draw calendar and astronomy info in 30mm-tall header
- remove month/year label from calendar
- add 6mm margins and header dividing line

## Testing
- `python -m py_compile gen_page.py widgets/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68814cd7cd388325bc06571f4a121a49