### PR TITLE
Update calendar margins

### DIFF
--- a/gen_page.py
+++ b/gen_page.py
@@ -8,6 +8,7 @@ DEFAULT_PATH = "page.pdf"
 
 HEADER_HEIGHT = 30 * mm
 MARGIN = 6 * mm
+CALENDAR_MARGIN = 5 * mm
 
 
 def create_page(output_path=DEFAULT_PATH):
@@ -18,7 +19,7 @@ def create_page(output_path=DEFAULT_PATH):
     header_top = height - MARGIN
     header_bottom = header_top - HEADER_HEIGHT
 
-    calendar.draw(c, header_top, header_bottom, margin=MARGIN)
+    calendar.draw(c, header_top, header_bottom, margin=CALENDAR_MARGIN)
     astro.draw(c, header_top - 12, margin=MARGIN)
 
     c.setLineWidth(1)

--- a/widgets/calendar.py
+++ b/widgets/calendar.py
@@ -5,20 +5,30 @@ from reportlab.lib import colors
 from reportlab.lib.units import mm
 
 
-def draw(c, top_y, bottom_y, margin=6 * mm):
-    """Draw a simple month grid inside the given header bounds."""
+def draw(c, top_y, bottom_y, margin=5 * mm):
+    """Draw a simple month grid inside the given header bounds.
+
+    The ``margin`` parameter controls the padding inside the header on
+    all sides.  The calendar grid starts ``margin`` units from the
+    header's edges and fits within the remaining space.
+    """
     today = datetime.today()
     year = today.year
     month = today.month
     day = today.day
 
+    width, _ = A6
+
     month_matrix = calendar.monthcalendar(year, month)
     rows = len(month_matrix)
 
-    cell_size = (top_y - bottom_y) / rows
+    available_height = top_y - bottom_y - 2 * margin
+    available_width = width - 2 * margin
+
+    cell_size = min(available_height / rows, available_width / 7)
 
     start_x = margin
-    start_y = top_y - cell_size
+    start_y = top_y - margin - cell_size
     padding = cell_size * 0.3
 
     c.setFont("Courier", 8)


### PR DESCRIPTION
## Summary
- tweak layout so the calendar has a 5 mm margin
- keep page margins the same

## Testing
- `python gen_page.py`

------
https://chatgpt.com/codex/tasks/task_e_6881612c268c83259d5422c788ed63a4