### PR TITLE
Update calendar layout and astro info

### DIFF
--- a/gen_page.py
+++ b/gen_page.py
@@ -8,6 +8,7 @@ DEFAULT_PATH = "page.pdf"
 
 HEADER_HEIGHT = 30 * mm
 MARGIN = 6 * mm
+CALENDAR_BOTTOM_PAD = 5 * mm
 
 
 def create_page(output_path=DEFAULT_PATH):
@@ -18,7 +19,8 @@ def create_page(output_path=DEFAULT_PATH):
     header_top = height - MARGIN
     header_bottom = header_top - HEADER_HEIGHT
 
-    calendar.draw(c, header_top, header_bottom, margin=MARGIN)
+    calendar.draw(c, header_top, header_bottom, margin=MARGIN,
+                  bottom_pad=CALENDAR_BOTTOM_PAD)
     astro.draw(c, header_top - 12, margin=MARGIN)
 
     c.setLineWidth(1)

--- a/widgets/astro.py
+++ b/widgets/astro.py
@@ -1,17 +1,20 @@
 from datetime import date
 from astral import LocationInfo
-from astral.sun import sun
+from astral.sun import sun, elevation
 from reportlab.lib.pagesizes import A6
 from reportlab.lib.units import mm
 
 
 def draw(c, top_y, margin=6 * mm):
-    """Draw sunrise and sunset times at the top right of the header."""
+    """Draw basic solar information at the top right of the header."""
     location = LocationInfo("London", "England", "UTC", 51.5, -0.1)
     s = sun(location.observer, date=date.today(), tzinfo=location.timezone)
 
     sunrise = s["sunrise"].strftime("%H:%M")
     sunset = s["sunset"].strftime("%H:%M")
+    noon = s["noon"]
+    noon_time = noon.strftime("%H:%M")
+    noon_angle = elevation(location.observer, noon)
 
     width, _ = A6
     x = width - margin
@@ -20,4 +23,9 @@ def draw(c, top_y, margin=6 * mm):
     c.setFont("Courier", 10)
     c.drawRightString(x, y, f"Sunrise {sunrise}")
     c.drawRightString(x, y - 12, f"Sunset {sunset}")
+    c.drawRightString(
+        x,
+        y - 24,
+        f"Solar noon {noon_time} {noon_angle:.1f}\N{DEGREE SIGN}",
+    )
 

--- a/widgets/calendar.py
+++ b/widgets/calendar.py
@@ -1,12 +1,16 @@
 from datetime import datetime
 import calendar
-from reportlab.lib.pagesizes import A6
 from reportlab.lib import colors
 from reportlab.lib.units import mm
 
 
-def draw(c, top_y, bottom_y, margin=6 * mm):
-    """Draw a simple month grid inside the given header bounds."""
+def draw(c, top_y, bottom_y, margin=6 * mm, bottom_pad=5 * mm):
+    """Draw a simple month grid inside the given header bounds.
+
+    ``margin`` is the left margin used to align the grid with the rest of
+    the page. ``bottom_pad`` adds a gap below the grid while allowing the
+    top row to sit flush with ``top_y``.
+    """
     today = datetime.today()
     year = today.year
     month = today.month
@@ -15,7 +19,7 @@ def draw(c, top_y, bottom_y, margin=6 * mm):
     month_matrix = calendar.monthcalendar(year, month)
     rows = len(month_matrix)
 
-    cell_size = (top_y - bottom_y) / rows
+    cell_size = (top_y - bottom_y - bottom_pad) / rows
 
     start_x = margin
     start_y = top_y - cell_size


### PR DESCRIPTION
## Summary
- align calendar with top of header and add configurable bottom padding
- include solar noon time and angle in astro widget

## Testing
- `python gen_page.py`

------
https://chatgpt.com/codex/tasks/task_e_6881612c268c83259d5422c788ed63a4