### PR TITLE
Fix missing reportlab pagesize import

### DIFF
--- a/widgets/calendar.py
+++ b/widgets/calendar.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import calendar
 from reportlab.lib import colors
 from reportlab.lib.units import mm
+from reportlab.lib.pagesizes import A6
 
 
 def draw(c, top_y, bottom_y, margin=6 * mm, bottom_pad=5 * mm):


### PR DESCRIPTION
## Summary
- fix calendar widget by importing `A6` from `reportlab.lib.pagesizes`

## Testing
- `pytest -q`
- `python3 gen_page.py && ls -l page.pdf | head`

------
https://chatgpt.com/codex/tasks/task_e_688164bb1b048325a41e1ad738f498e4