### PR TITLE
Add header and calendar background colors

### DIFF
--- a/gen_page.py
+++ b/gen_page.py
@@ -1,6 +1,7 @@
 from reportlab.lib.pagesizes import A6
 from reportlab.pdfgen import canvas
 from reportlab.lib.units import mm
+from reportlab.lib import colors
 
 from widgets import calendar, astro
 
@@ -19,8 +20,16 @@ def create_page(output_path=DEFAULT_PATH):
     header_top = height - MARGIN
     header_bottom = header_top - HEADER_HEIGHT
 
-    calendar.draw(c, header_top, header_bottom, margin=MARGIN,
-                  bottom_pad=CALENDAR_BOTTOM_PAD)
+    c.setFillColor(colors.lightblue)
+    c.rect(MARGIN, header_bottom, width - 2 * MARGIN, HEADER_HEIGHT, stroke=0, fill=1)
+
+    calendar.draw(
+        c,
+        header_top,
+        header_bottom,
+        margin=MARGIN,
+        bottom_pad=CALENDAR_BOTTOM_PAD,
+    )
 
     astro.draw(c, header_top - 12, margin=MARGIN)
 
@@ -33,4 +42,3 @@ def create_page(output_path=DEFAULT_PATH):
 
 if __name__ == "__main__":
     create_page()
-

--- a/widgets/calendar.py
+++ b/widgets/calendar.py
@@ -28,6 +28,14 @@ def draw(c, top_y, bottom_y, margin=6 * mm, bottom_pad=5 * mm):
     start_y = top_y - margin - cell_size
     padding = cell_size * 0.3
 
+    grid_width = cell_size * 7
+    grid_height = cell_size * rows
+    grid_bottom = start_y - (rows - 1) * cell_size
+
+    c.setFillColor(colors.blue)
+    c.rect(start_x, grid_bottom, grid_width, grid_height, fill=1, stroke=0)
+    c.setFillColor(colors.black)
+
     c.setFont("Courier", 8)
 
     for row_idx, week in enumerate(month_matrix):
@@ -49,4 +57,3 @@ def draw(c, top_y, bottom_y, margin=6 * mm, bottom_pad=5 * mm):
             c.drawCentredString(x + cell_size / 2, y + padding, f"{date:2}")
 
     c.setFillColor(colors.black)
-


### PR DESCRIPTION
## Summary
- paint the header light blue
- fill the calendar background blue

## Testing
- `python gen_page.py`

------
https://chatgpt.com/codex/tasks/task_e_688165a30994832594775dfeb7f10662