### PR TITLE
Fix calendar vertical alignment

### DIFF
--- a/widgets/calendar.py
+++ b/widgets/calendar.py
@@ -25,7 +25,7 @@ def draw(c, top_y, bottom_y, margin=6 * mm, bottom_pad=5 * mm):
     cell_size = (top_y - bottom_y - bottom_pad) / rows
 
     start_x = margin
-    start_y = top_y - margin - cell_size
+    start_y = top_y - cell_size
     padding = cell_size * 0.3
 
     grid_width = cell_size * 7


### PR DESCRIPTION
## Summary
- ensure calendar aligns with header by removing unused vertical margin offset

## Testing
- `python -m compileall -q widgets`

------
https://chatgpt.com/codex/tasks/task_e_68816738b81c8325ae574ec6cf1378ee